### PR TITLE
ci: ship Windows import lib (livekit_ffi.dll.lib) in the livekit-ffi conan package

### DIFF
--- a/.azure/pipelines/ffi-builds-templates/ffi-stage-template.yml
+++ b/.azure/pipelines/ffi-builds-templates/ffi-stage-template.yml
@@ -102,7 +102,13 @@ stages:
         script: |
           Set-Location "target/${{ parameters.target }}/release/"
           $null = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/${{ parameters.name }}/lib/windows" -Force
-          $files = @("${{ parameters.dylib }}", "${{ parameters.jar }}") | Where-Object { $_ -and (Test-Path $_) }
+          # A Rust cdylib on MSVC emits both the DLL and its import library (<dll>.lib).
+          # The import lib is required to link the FFI symbols (livekit_ffi_*) from
+          # consumers such as dnbroadcast / Broadcast.exe. Without it the Conan package
+          # ships only the DLL, collect_libs() finds no .lib, and consumers fail to link
+          # (LNK2019 on livekit_ffi_initialize / livekit_ffi_request).
+          $dll = "${{ parameters.dylib }}"
+          $files = @($dll, "$dll.lib", "${{ parameters.jar }}") | Where-Object { $_ -and (Test-Path $_) }
 
           if ($files.Count -gt 0) {
               Copy-Item -Path $files -Destination "$(Pipeline.Workspace)/${{ parameters.name }}/lib/windows"


### PR DESCRIPTION
## Problema
El paquete Conan `livekit-ffi` de Windows se publica **sin la import library**, así que cualquier consumidor que enlace los símbolos del FFI falla en el linker.

En `.azure/pipelines/ffi-builds-templates/ffi-stage-template.yml`, el paso *Zip artifact (Windows)* copiaba solo `livekit_ffi.dll` (+ jar). Un `cdylib` de Rust en MSVC emite **`livekit_ffi.dll` + `livekit_ffi.dll.lib`**. Al no copiar el `.dll.lib`:
1. El artefacto `ffi-windows-x86_64` → `lib/windows/` solo tiene el `.dll`.
2. `conan_assets/conanfile.py` copia `*.lib` de `lib/windows` → no hay ninguno.
3. `package_info`: `tools.collect_libs()` devuelve **vacío**.
4. Consumidores (`dnbroadcast` → `goliath-windows` `Broadcast.exe`) fallan: `LNK2019` en `livekit_ffi_initialize` / `livekit_ffi_request` → `LNK1120`.

## Cambio
Copiar también la import lib (`$dll.lib` → `livekit_ffi.dll.lib`) al artefacto Windows. El `conanfile.py` ya la recoge sin cambios.

## Contexto / regresión
El template Azure del FFI se introdujo el 2025-04-07; el último build **verde** de goliath-windows fue el 2025-04-03 (con `livekit-ffi/0.7.2` empaquetado del modo antiguo, **con** import lib). Al republicar con este pipeline (que omite el `.lib`), goliath dejó de enlazar. Investigación completa en DisplayNote/goliath-windows#70.

## Para desbloquear goliath-windows
⚠️ Este fix corrige el empaquetado de aquí en adelante. Como `main` ya avanzó a un FFI/WebRTC más nuevo (webrtc 138) **incompatible** con el `dnbroadcast/3.0.1` de goliath, para desbloquear esa versión hay que **rebuild + republish de `livekit-ffi/0.7.2@dn/stable`** desde el ref de la 0.7.2 **con este fix** — o migrar goliath al stack nuevo (cambio mayor).

## Nota
El workflow upstream `.github/workflows/ffi-builds.yml` (release zip, no alimenta el Conan de DN) tiene la misma omisión; se deja fuera para no divergir del upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)