### PR TITLE
  AB#135683 [Receiver][Android][Newline STV] Clients cannot connect to B2P

### DIFF
--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -40,19 +40,39 @@ pub struct PeerConnectionFactory {
     pub(crate) sys_handle: SharedPtr<sys_pcf::ffi::PeerConnectionFactory>,
 }
 
-impl Default for PeerConnectionFactory {
-    fn default() -> Self {
+impl PeerConnectionFactory {
+    /// Creates a PeerConnectionFactory.
+    ///
+    /// `force_sw_h264`: when `true`, H264 is always encoded via the Android SW
+    /// MediaCodec encoder (`c2.android.avc.encoder`) instead of the HW encoder.
+    /// Determine this value by calling [`android_h264_needs_sw_fallback()`] once
+    /// at application startup.  On non-Android platforms the flag is ignored.
+    pub fn new(force_sw_h264: bool) -> Self {
         let mut log_sink = LOG_SINK.lock();
         if log_sink.is_none() {
             *log_sink = Some(sys_rtc::ffi::new_log_sink(|msg, _| {
                 let msg = msg.strip_suffix("\r\n").or(msg.strip_suffix('\n')).unwrap_or(&msg);
-
                 log::debug!(target: "libwebrtc", "{}", msg);
             }));
         }
-
-        Self { sys_handle: sys_pcf::ffi::create_peer_connection_factory() }
+        Self { sys_handle: sys_pcf::ffi::create_peer_connection_factory(force_sw_h264) }
     }
+}
+
+impl Default for PeerConnectionFactory {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+/// Returns `true` if the first HW H264 encoder on this Android device is on the
+/// SW-fallback blocklist (known to produce non-standard SPS NALs at runtime).
+/// Always returns `false` on non-Android platforms.
+///
+/// Call this once at application startup and pass the result as `force_sw_h264`
+/// to [`PeerConnectionFactory::new()`].
+pub fn android_h264_needs_sw_fallback() -> bool {
+    sys_pcf::ffi::android_h264_needs_sw_fallback()
 }
 
 impl PeerConnectionFactory {

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -45,8 +45,8 @@ impl PeerConnectionFactory {
     ///
     /// `force_sw_h264`: when `true`, H264 is always encoded via the Android SW
     /// MediaCodec encoder (`c2.android.avc.encoder`) instead of the HW encoder.
-    /// Determine this value by calling [`android_h264_needs_sw_fallback()`] once
-    /// at application startup.  On non-Android platforms the flag is ignored.
+    /// The caller is responsible for determining this value based on device/chipset
+    /// policy.  On non-Android platforms the flag is ignored.
     pub fn new(force_sw_h264: bool) -> Self {
         let mut log_sink = LOG_SINK.lock();
         if log_sink.is_none() {

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -65,16 +65,6 @@ impl Default for PeerConnectionFactory {
     }
 }
 
-/// Returns `true` if the first HW H264 encoder on this Android device is on the
-/// SW-fallback blocklist (known to produce non-standard SPS NALs at runtime).
-/// Always returns `false` on non-Android platforms.
-///
-/// Call this once at application startup and pass the result as `force_sw_h264`
-/// to [`PeerConnectionFactory::new()`].
-pub fn android_h264_needs_sw_fallback() -> bool {
-    sys_pcf::ffi::android_h264_needs_sw_fallback()
-}
-
 impl PeerConnectionFactory {
     pub fn create_peer_connection(
         &self,

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -43,10 +43,11 @@ pub struct PeerConnectionFactory {
 impl PeerConnectionFactory {
     /// Creates a PeerConnectionFactory.
     ///
-    /// `force_sw_h264`: when `true`, H264 is always encoded via the Android SW
-    /// MediaCodec encoder (`c2.android.avc.encoder`) instead of the HW encoder.
-    /// The caller is responsible for determining this value based on device/chipset
-    /// policy.  On non-Android platforms the flag is ignored.
+    /// `force_sw_h264`: when `true`, H264 encoding prefers the Android SW MediaCodec
+    /// encoder (`c2.android.avc.encoder`) over the HW encoder.  Best-effort: falls
+    /// back to HW if the SW factory cannot be created (e.g., stale jar), and effective
+    /// on API 29+ only.  The caller is responsible for the device/chipset policy
+    /// decision.  On non-Android platforms the flag is ignored.
     pub fn new(force_sw_h264: bool) -> Self {
         let mut log_sink = LOG_SINK.lock();
         if log_sink.is_none() {
@@ -122,6 +123,16 @@ mod tests {
         let _ = env_logger::builder().is_test(true).try_init();
 
         let factory = PeerConnectionFactory::default();
+        let source = NativeVideoSource::default();
+        let _track = factory.create_video_track("test", source);
+        drop(factory);
+    }
+
+    #[tokio::test]
+    async fn test_peer_connection_factory_force_sw_h264() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let factory = PeerConnectionFactory::new(true);
         let source = NativeVideoSource::default();
         let _track = factory.create_video_track("test", source);
         drop(factory);

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -70,10 +70,11 @@ impl Debug for PeerConnectionFactory {
 impl PeerConnectionFactory {
     /// Creates a PeerConnectionFactory.
     ///
-    /// `force_sw_h264`: when `true`, H264 is always encoded via the Android SW
-    /// MediaCodec encoder instead of the HW encoder.  The caller is responsible
-    /// for determining this value based on device/chipset policy.  On non-Android
-    /// platforms the flag is ignored.
+    /// `force_sw_h264`: when `true`, H264 encoding prefers the Android SW MediaCodec
+    /// encoder over the HW encoder.  Best-effort: falls back to HW if the SW factory
+    /// cannot be created (e.g., stale jar), and effective on API 29+ only.  The caller
+    /// is responsible for the device/chipset policy decision.  On non-Android platforms
+    /// the flag is ignored.
     pub fn new(force_sw_h264: bool) -> Self {
         Self { handle: imp_pcf::PeerConnectionFactory::new(force_sw_h264) }
     }

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -71,8 +71,8 @@ impl PeerConnectionFactory {
     /// Creates a PeerConnectionFactory.
     ///
     /// `force_sw_h264`: when `true`, H264 is always encoded via the Android SW
-    /// MediaCodec encoder instead of the HW encoder.  Determine this value by
-    /// calling [`android_h264_needs_sw_fallback()`] at startup; on non-Android
+    /// MediaCodec encoder instead of the HW encoder.  The caller is responsible
+    /// for determining this value based on device/chipset policy.  On non-Android
     /// platforms the flag is ignored.
     pub fn new(force_sw_h264: bool) -> Self {
         Self { handle: imp_pcf::PeerConnectionFactory::new(force_sw_h264) }

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -19,6 +19,15 @@ use crate::{
     rtp_parameters::RtpCapabilities, MediaType, RtcError,
 };
 
+/// Returns `true` if the first HW H264 encoder on this Android device is on
+/// the SW-fallback blocklist.  Always returns `false` on non-Android platforms.
+///
+/// Call once at application startup and pass the result as `force_sw_h264` to
+/// [`PeerConnectionFactory::new()`].
+pub fn android_h264_needs_sw_fallback() -> bool {
+    imp_pcf::android_h264_needs_sw_fallback()
+}
+
 #[derive(Debug, Clone)]
 pub struct IceServer {
     pub urls: Vec<String>,
@@ -68,6 +77,16 @@ impl Debug for PeerConnectionFactory {
 }
 
 impl PeerConnectionFactory {
+    /// Creates a PeerConnectionFactory.
+    ///
+    /// `force_sw_h264`: when `true`, H264 is always encoded via the Android SW
+    /// MediaCodec encoder instead of the HW encoder.  Determine this value by
+    /// calling [`android_h264_needs_sw_fallback()`] at startup; on non-Android
+    /// platforms the flag is ignored.
+    pub fn new(force_sw_h264: bool) -> Self {
+        Self { handle: imp_pcf::PeerConnectionFactory::new(force_sw_h264) }
+    }
+
     pub fn create_peer_connection(
         &self,
         config: RtcConfiguration,

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -19,15 +19,6 @@ use crate::{
     rtp_parameters::RtpCapabilities, MediaType, RtcError,
 };
 
-/// Returns `true` if the first HW H264 encoder on this Android device is on
-/// the SW-fallback blocklist.  Always returns `false` on non-Android platforms.
-///
-/// Call once at application startup and pass the result as `force_sw_h264` to
-/// [`PeerConnectionFactory::new()`].
-pub fn android_h264_needs_sw_fallback() -> bool {
-    imp_pcf::android_h264_needs_sw_fallback()
-}
-
 #[derive(Debug, Clone)]
 pub struct IceServer {
     pub urls: Vec<String>,

--- a/libwebrtc/src/prelude.rs
+++ b/libwebrtc/src/prelude.rs
@@ -25,8 +25,8 @@ pub use crate::{
         PeerConnectionState, SignalingState,
     },
     peer_connection_factory::{
-        ContinualGatheringPolicy, IceServer, IceTransportsType, PeerConnectionFactory,
-        RtcConfiguration,
+        android_h264_needs_sw_fallback, ContinualGatheringPolicy, IceServer, IceTransportsType,
+        PeerConnectionFactory, RtcConfiguration,
     },
     rtp_parameters::*,
     rtp_receiver::RtpReceiver,

--- a/libwebrtc/src/prelude.rs
+++ b/libwebrtc/src/prelude.rs
@@ -25,7 +25,7 @@ pub use crate::{
         PeerConnectionState, SignalingState,
     },
     peer_connection_factory::{
-        android_h264_needs_sw_fallback, ContinualGatheringPolicy, IceServer, IceTransportsType,
+        ContinualGatheringPolicy, IceServer, IceTransportsType,
         PeerConnectionFactory, RtcConfiguration,
     },
     rtp_parameters::*,

--- a/livekit-ffi/include/livekit_ffi.h
+++ b/livekit-ffi/include/livekit_ffi.h
@@ -41,6 +41,12 @@ bool livekit_ffi_drop_handle(FfiHandleId handle_id);
 
 void livekit_ffi_dispose();
 
+/// Probes whether the Android HW H264 encoder is on the SW-fallback blocklist,
+/// stores the result, and returns it.  Must be called after WebRTC JNI
+/// initialization and before the first room connection.
+/// Always returns false on non-Android platforms.
+bool livekit_ffi_probe_android_h264();
+
 }  // extern "C"
 
 #endif  // livekit_ffi

--- a/livekit-ffi/include/livekit_ffi.h
+++ b/livekit-ffi/include/livekit_ffi.h
@@ -41,7 +41,7 @@ bool livekit_ffi_drop_handle(FfiHandleId handle_id);
 
 /// Explicitly sets whether the SW H264 encoder should be used instead of HW.
 /// The application calls this before the first room connection based on its
-/// own device/chipset policy.  On non-Android platforms this is a no-op.
+/// own device/chipset policy.  On non-Android platforms the flag is ignored.
 void livekit_ffi_set_force_sw_h264(bool force);
 
 void livekit_ffi_dispose();

--- a/livekit-ffi/include/livekit_ffi.h
+++ b/livekit-ffi/include/livekit_ffi.h
@@ -39,18 +39,12 @@ FfiHandleId livekit_ffi_request(const uint8_t *data,
 
 bool livekit_ffi_drop_handle(FfiHandleId handle_id);
 
-void livekit_ffi_dispose();
-
-/// Probes whether the Android HW H264 encoder is on the SW-fallback blocklist,
-/// stores the result, and returns it.  Must be called after WebRTC JNI
-/// initialization and before the first room connection.
-/// Always returns false on non-Android platforms.
-bool livekit_ffi_probe_android_h264();
-
 /// Explicitly sets whether the SW H264 encoder should be used instead of HW.
-/// Call before the first room connection.  Always a no-op on non-Android
-/// platforms.
+/// The application calls this before the first room connection based on its
+/// own device/chipset policy.  On non-Android platforms this is a no-op.
 void livekit_ffi_set_force_sw_h264(bool force);
+
+void livekit_ffi_dispose();
 
 }  // extern "C"
 

--- a/livekit-ffi/include/livekit_ffi.h
+++ b/livekit-ffi/include/livekit_ffi.h
@@ -47,6 +47,11 @@ void livekit_ffi_dispose();
 /// Always returns false on non-Android platforms.
 bool livekit_ffi_probe_android_h264();
 
+/// Explicitly sets whether the SW H264 encoder should be used instead of HW.
+/// Call before the first room connection.  Always a no-op on non-Android
+/// platforms.
+void livekit_ffi_set_force_sw_h264(bool force);
+
 }  // extern "C"
 
 #endif  // livekit_ffi

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -96,7 +96,7 @@ pub extern "C" fn livekit_ffi_drop_handle(handle_id: FfiHandleId) -> bool {
 
 /// Explicitly sets whether the SW H264 encoder should be used instead of HW.
 /// The application calls this before the first room connection based on its
-/// own device/chipset policy.  On non-Android platforms this is a no-op.
+/// own device/chipset policy.  On non-Android platforms the flag is ignored.
 #[no_mangle]
 pub extern "C" fn livekit_ffi_set_force_sw_h264(force: bool) {
     livekit::set_force_sw_h264(force);

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -114,6 +114,15 @@ pub extern "C" fn livekit_ffi_probe_android_h264() -> bool {
     false
 }
 
+/// Explicitly sets whether the SW H264 encoder should be used instead of HW.
+/// The application calls this before the first room connection based on its
+/// own device/chipset policy.  On non-Android platforms this is a no-op.
+#[no_mangle]
+pub extern "C" fn livekit_ffi_set_force_sw_h264(force: bool) {
+    livekit::set_force_sw_h264(force);
+    log::info!("livekit_ffi_set_force_sw_h264: force_sw_h264={}", force);
+}
+
 #[no_mangle]
 pub extern "C" fn livekit_ffi_dispose() {
     FFI_SERVER.async_runtime.block_on(FFI_SERVER.dispose());

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -94,26 +94,6 @@ pub extern "C" fn livekit_ffi_drop_handle(handle_id: FfiHandleId) -> bool {
     FFI_SERVER.drop_handle(handle_id)
 }
 
-/// Probes whether the Android HW H264 encoder is on the SW-fallback blocklist,
-/// stores the result, and returns it.  The result is read by `LkRuntime` when
-/// it creates its `PeerConnectionFactory` on the first room connection.
-///
-/// Must be called after WebRTC JNI initialization and before the first room
-/// connection.  On non-Android platforms always returns false.
-#[no_mangle]
-pub extern "C" fn livekit_ffi_probe_android_h264() -> bool {
-    #[cfg(target_os = "android")]
-    {
-        let needs_sw =
-            livekit::webrtc::peer_connection_factory::android_h264_needs_sw_fallback();
-        livekit::set_force_sw_h264(needs_sw);
-        log::info!("livekit_ffi_probe_android_h264: force_sw_h264={}", needs_sw);
-        needs_sw
-    }
-    #[cfg(not(target_os = "android"))]
-    false
-}
-
 /// Explicitly sets whether the SW H264 encoder should be used instead of HW.
 /// The application calls this before the first room connection based on its
 /// own device/chipset policy.  On non-Android platforms this is a no-op.

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -94,6 +94,26 @@ pub extern "C" fn livekit_ffi_drop_handle(handle_id: FfiHandleId) -> bool {
     FFI_SERVER.drop_handle(handle_id)
 }
 
+/// Probes whether the Android HW H264 encoder is on the SW-fallback blocklist,
+/// stores the result, and returns it.  The result is read by `LkRuntime` when
+/// it creates its `PeerConnectionFactory` on the first room connection.
+///
+/// Must be called after WebRTC JNI initialization and before the first room
+/// connection.  On non-Android platforms always returns false.
+#[no_mangle]
+pub extern "C" fn livekit_ffi_probe_android_h264() -> bool {
+    #[cfg(target_os = "android")]
+    {
+        let needs_sw =
+            livekit::webrtc::peer_connection_factory::android_h264_needs_sw_fallback();
+        livekit::set_force_sw_h264(needs_sw);
+        log::info!("livekit_ffi_probe_android_h264: force_sw_h264={}", needs_sw);
+        needs_sw
+    }
+    #[cfg(not(target_os = "android"))]
+    false
+}
+
 #[no_mangle]
 pub extern "C" fn livekit_ffi_dispose() {
     FFI_SERVER.async_runtime.block_on(FFI_SERVER.dispose());

--- a/livekit/src/lib.rs
+++ b/livekit/src/lib.rs
@@ -34,3 +34,10 @@ pub mod dispatcher {
 }
 
 pub use plugin::*;
+
+/// Configures whether the Android SW H264 encoder should be used instead of HW.
+/// Call before the first room connection (before `LkRuntime` is created).
+/// On non-Android platforms this is a no-op.
+pub fn set_force_sw_h264(val: bool) {
+    rtc_engine::lk_runtime::set_force_sw_h264(val);
+}

--- a/livekit/src/lib.rs
+++ b/livekit/src/lib.rs
@@ -37,7 +37,7 @@ pub use plugin::*;
 
 /// Configures whether the Android SW H264 encoder should be used instead of HW.
 /// Call before the first room connection (before `LkRuntime` is created).
-/// On non-Android platforms this is a no-op.
+/// On non-Android platforms the flag is ignored.
 pub fn set_force_sw_h264(val: bool) {
     rtc_engine::lk_runtime::set_force_sw_h264(val);
 }

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -29,6 +29,12 @@ use parking_lot::Mutex;
 static FORCE_SW_H264: AtomicBool = AtomicBool::new(false);
 
 pub fn set_force_sw_h264(val: bool) {
+    if LK_RUNTIME.lock().upgrade().is_some() {
+        log::warn!(
+            "set_force_sw_h264({}) called after LkRuntime was already created — flag has no effect",
+            val
+        );
+    }
     FORCE_SW_H264.store(val, Ordering::SeqCst);
 }
 

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -29,13 +29,22 @@ use parking_lot::Mutex;
 static FORCE_SW_H264: AtomicBool = AtomicBool::new(false);
 
 pub fn set_force_sw_h264(val: bool) {
-    if LK_RUNTIME.lock().upgrade().is_some() {
+    // Hold the lock across both the check and the store so that
+    // LkRuntime::instance() (which reads FORCE_SW_H264 under the same lock)
+    // cannot race between the two operations.
+    let already_alive = {
+        let _guard = LK_RUNTIME.lock();
+        let alive = _guard.upgrade().is_some();
+        FORCE_SW_H264.store(val, Ordering::SeqCst);
+        alive
+    };
+    if already_alive {
         log::warn!(
-            "set_force_sw_h264({}) called after LkRuntime was already created — flag has no effect",
+            "set_force_sw_h264({}) called after LkRuntime was already created \
+             — flag will not affect the current runtime instance",
             val
         );
     }
-    FORCE_SW_H264.store(val, Ordering::SeqCst);
 }
 
 lazy_static! {

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -14,12 +14,23 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    sync::{Arc, Weak},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Weak,
+    },
 };
 
 use lazy_static::lazy_static;
 use libwebrtc::prelude::*;
 use parking_lot::Mutex;
+
+// Set by livekit_ffi_probe_android_h264() before the first room connection.
+// LkRuntime reads this once when creating PeerConnectionFactory.
+static FORCE_SW_H264: AtomicBool = AtomicBool::new(false);
+
+pub fn set_force_sw_h264(val: bool) {
+    FORCE_SW_H264.store(val, Ordering::SeqCst);
+}
 
 lazy_static! {
     static ref LK_RUNTIME: Mutex<Weak<LkRuntime>> = Mutex::new(Weak::new());
@@ -42,7 +53,11 @@ impl LkRuntime {
             lk_runtime
         } else {
             log::debug!("LkRuntime::new()");
-            let new_runtime = Arc::new(Self { pc_factory: PeerConnectionFactory::default() });
+            let new_runtime = Arc::new(Self {
+                pc_factory: PeerConnectionFactory::new(
+                    FORCE_SW_H264.load(Ordering::SeqCst),
+                ),
+            });
             *lk_runtime_ref = Arc::downgrade(&new_runtime);
             new_runtime
         }

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -24,7 +24,7 @@ use lazy_static::lazy_static;
 use libwebrtc::prelude::*;
 use parking_lot::Mutex;
 
-// Set by livekit_ffi_probe_android_h264() before the first room connection.
+// Set by livekit_ffi_set_force_sw_h264() before the first room connection.
 // LkRuntime reads this once when creating PeerConnectionFactory.
 static FORCE_SW_H264: AtomicBool = AtomicBool::new(false);
 

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -558,14 +558,11 @@ fn configure_and_build_x264_android(
 
 fn configure_android_sysroot(builder: &mut cc::Build) {
     let toolchain = webrtc_sys_build::android_ndk_toolchain().unwrap();
-    let toolchain_lib = toolchain.join("lib");
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
 
     let sysroot = toolchain.join("sysroot").canonicalize().unwrap();
-    // Do not add this on Android x86_64 to avoid linking with host libraries when crossbuillding in Linux
-    if target_arch != "x86_64" {
-        println!("cargo:rustc-link-search={}", toolchain_lib.display());
-    }
+    // Do NOT add toolchain/lib to the search path: it contains host (x86_64) libraries
+    // that are incompatible with ARM targets.  cargo-ndk's clang linker wrapper already
+    // passes the correct sysroot to ld.lld so target-specific libc++abi.a is found there.
 
     builder.flag(format!("-isysroot{}", sysroot.display()).as_str());
 }

--- a/webrtc-sys/include/livekit/android/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/android/video_encoder_factory.h
@@ -25,17 +25,10 @@
 
 namespace livekit {
 
-// Returns true if the first HW H264 encoder found on this device is on the
-// SW-fallback blocklist (known to produce non-standard SPS NALs at runtime).
-// Call this once at application startup to decide the force_sw_h264 flag
-// passed to create_peer_connection_factory().
-bool AndroidH264NeedsSwFallback();
-
 class AndroidVideoEncoderFactory : public webrtc::VideoEncoderFactory {
  public:
   // force_sw_h264: when true, H264 is always encoded via the SW MediaCodec
-  // encoder (c2.android.avc.encoder) instead of the HW encoder.  Callers
-  // determine this flag by calling AndroidH264NeedsSwFallback() at startup.
+  // encoder (c2.android.avc.encoder) instead of the HW encoder.
   explicit AndroidVideoEncoderFactory(bool force_sw_h264 = false);
   ~AndroidVideoEncoderFactory() override;
 

--- a/webrtc-sys/include/livekit/android/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/android/video_encoder_factory.h
@@ -27,8 +27,10 @@ namespace livekit {
 
 class AndroidVideoEncoderFactory : public webrtc::VideoEncoderFactory {
  public:
-  // force_sw_h264: when true, H264 is always encoded via the SW MediaCodec
-  // encoder (c2.android.avc.encoder) instead of the HW encoder.
+  // force_sw_h264: when true, H264 encoding prefers the SW MediaCodec encoder
+  // (c2.android.avc.encoder) over the HW encoder.  Best-effort: falls back to
+  // HW if the SW factory cannot be created (e.g., stale jar / missing ctor).
+  // Effective on API 29+ only; on earlier APIs HW may still be selected.
   explicit AndroidVideoEncoderFactory(bool force_sw_h264 = false);
   ~AndroidVideoEncoderFactory() override;
 

--- a/webrtc-sys/include/livekit/android/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/android/video_encoder_factory.h
@@ -25,9 +25,18 @@
 
 namespace livekit {
 
+// Returns true if the first HW H264 encoder found on this device is on the
+// SW-fallback blocklist (known to produce non-standard SPS NALs at runtime).
+// Call this once at application startup to decide the force_sw_h264 flag
+// passed to create_peer_connection_factory().
+bool AndroidH264NeedsSwFallback();
+
 class AndroidVideoEncoderFactory : public webrtc::VideoEncoderFactory {
  public:
-  AndroidVideoEncoderFactory();
+  // force_sw_h264: when true, H264 is always encoded via the SW MediaCodec
+  // encoder (c2.android.avc.encoder) instead of the HW encoder.  Callers
+  // determine this flag by calling AndroidH264NeedsSwFallback() at startup.
+  explicit AndroidVideoEncoderFactory(bool force_sw_h264 = false);
   ~AndroidVideoEncoderFactory() override;
 
   std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
@@ -48,8 +57,11 @@ class AndroidVideoEncoderFactory : public webrtc::VideoEncoderFactory {
   const std::unique_ptr<webrtc::VideoEncoderFactory> m_builtinEncoderFactory;
   std::unique_ptr<webrtc::VideoEncoderFactory> m_hwEncoderFactory;
   std::unique_ptr<webrtc::VideoEncoderFactory> m_swEncoderFactory;
+  // Non-null when force_sw_h264=true — SW MediaCodec H264 encoder factory.
+  std::unique_ptr<webrtc::VideoEncoderFactory> m_swH264EncoderFactory;
 };
 
-std::unique_ptr<webrtc::VideoEncoderFactory> CreateAndroidVideoEncoderFactory();
+std::unique_ptr<webrtc::VideoEncoderFactory> CreateAndroidVideoEncoderFactory(
+    bool force_sw_h264 = false);
 
 }  // namespace livekit

--- a/webrtc-sys/include/livekit/android/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/android/video_encoder_factory.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "api/video_codecs/sdp_video_format.h"

--- a/webrtc-sys/include/livekit/peer_connection_factory.h
+++ b/webrtc-sys/include/livekit/peer_connection_factory.h
@@ -41,7 +41,8 @@ webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
 
 class PeerConnectionFactory {
  public:
-  explicit PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime);
+  explicit PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime,
+                                 bool force_sw_h264 = false);
   ~PeerConnectionFactory();
 
   std::shared_ptr<PeerConnection> create_peer_connection(
@@ -69,5 +70,12 @@ class PeerConnectionFactory {
   webrtc::TaskQueueFactory* task_queue_factory_;
 };
 
-std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory();
+std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory(
+    bool force_sw_h264 = false);
+
+// Returns true if the first HW H264 encoder on this Android device is on the
+// SW-fallback blocklist.  Always returns false on non-Android platforms.
+// Call this once at application startup; pass the result as force_sw_h264 to
+// create_peer_connection_factory().
+bool android_h264_needs_sw_fallback();
 }  // namespace livekit

--- a/webrtc-sys/include/livekit/peer_connection_factory.h
+++ b/webrtc-sys/include/livekit/peer_connection_factory.h
@@ -73,9 +73,4 @@ class PeerConnectionFactory {
 std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory(
     bool force_sw_h264 = false);
 
-// Returns true if the first HW H264 encoder on this Android device is on the
-// SW-fallback blocklist.  Always returns false on non-Android platforms.
-// Call this once at application startup; pass the result as force_sw_h264 to
-// create_peer_connection_factory().
-bool android_h264_needs_sw_fallback();
 }  // namespace livekit

--- a/webrtc-sys/include/livekit/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/video_encoder_factory.h
@@ -23,7 +23,7 @@ namespace livekit {
 class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
   class InternalFactory : public webrtc::VideoEncoderFactory {
    public:
-    InternalFactory();
+    explicit InternalFactory(bool force_sw_h264 = false);
 
     std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
 
@@ -39,7 +39,7 @@ class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
   };
 
  public:
-  VideoEncoderFactory();
+  explicit VideoEncoderFactory(bool force_sw_h264 = false);
 
   std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
 

--- a/webrtc-sys/libwebrtc/.gclient
+++ b/webrtc-sys/libwebrtc/.gclient
@@ -7,3 +7,4 @@ solutions = [
     "managed": False,
   },
 ]
+target_os = ["android", "unix"]

--- a/webrtc-sys/libwebrtc/build_android.sh
+++ b/webrtc-sys/libwebrtc/build_android.sh
@@ -139,6 +139,7 @@ patches=(
   "ssl_verify_callback_with_native_handle.patch"
   "add_deps.patch"
   "android_use_libunwind.patch"
+  "sw_h264_fallback.patch"
 )
 
 patch_failed=false

--- a/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
+++ b/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
@@ -5,7 +5,7 @@
    private final boolean enableH264HighProfile;
    @Nullable private final Predicate<MediaCodecInfo> codecAllowedPredicate;
 +  private final boolean allowSoftwareCodecs;
- 
+
    /**
     * Creates a HardwareVideoEncoderFactory that supports surface texture encoding.
 @@ -59,7 +60,7 @@
@@ -15,7 +15,7 @@
 -        /* codecAllowedPredicate= */ null);
 +        /* codecAllowedPredicate= */ null, /* allowSoftwareCodecs= */ false);
    }
- 
+
    /**
 @@ -74,6 +75,13 @@
     */
@@ -31,63 +31,20 @@
      // Texture mode requires EglBase14.
      if (sharedContext instanceof EglBase14.Context) {
        this.sharedContext = (EglBase14.Context) sharedContext;
-@@ -84,6 +92,50 @@
+@@ -84,6 +92,7 @@
      this.enableIntelVp8Encoder = enableIntelVp8Encoder;
      this.enableH264HighProfile = enableH264HighProfile;
      this.codecAllowedPredicate = codecAllowedPredicate;
 +    this.allowSoftwareCodecs = allowSoftwareCodecs;
-+  }
-+
-+  /**
-+   * Returns the codec name of the first HW H264 encoder if it is on the SW-fallback blocklist
-+   * (known to produce SPS NALs with a hardcoded level that breaks client decoders when the SDP
-+   * negotiated Level 3.1), or {@code null} if the encoder appears compliant or no HW H264 encoder
-+   * is found.
-+   */
-+  @Nullable
-+  public static String findNonCompliantHardwareH264EncoderName() {
-+    // Encoders known to produce non-standard H264 SPS at runtime regardless of what level they
-+    // declare in profileLevels. Do not use a capability check here — many compliant encoders
-+    // (e.g. Qualcomm c2.qti.avc.encoder) only advertise high levels without enumerating Level 3.1.
-+    final String[] NAME_BLOCKLIST = {"OMX.realtek."};
-+
-+    final MediaCodecList list = new MediaCodecList(MediaCodecList.ALL_CODECS);
-+    for (MediaCodecInfo info : list.getCodecInfos()) {
-+      if (info == null || !info.isEncoder()) continue;
-+      if (!MediaCodecUtils.codecSupportsType(info, VideoCodecMimeType.H264)) continue;
-+
-+      // Identify hardware encoders using the same criteria as isHardwareSupportedInCurrentSdk().
-+      final boolean isHw;
-+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-+        isHw = info.isHardwareAccelerated();
-+      } else {
-+        final String n = info.getName();
-+        isHw = n.startsWith(QCOM_PREFIX) || n.startsWith(EXYNOS_PREFIX)
-+            || n.startsWith(INTEL_PREFIX);
-+      }
-+      if (!isHw) continue;
-+
-+      final String name = info.getName();
-+      for (final String prefix : NAME_BLOCKLIST) {
-+        if (name.startsWith(prefix)) {
-+          Logging.w(TAG, name + " is on SW-fallback blocklist — SW encoder will be used");
-+          return name;
-+        }
-+      }
-+
-+      // First HW H264 encoder found and not on blocklist — use it.
-+      return null;
-+    }
-+    return null;
    }
- 
+
    @Deprecated
-@@ -186,7 +238,7 @@
+@@ -186,7 +195,7 @@
    // current SDK.
    private boolean isHardwareSupportedInCurrentSdk(MediaCodecInfo info, VideoCodecMimeType type) {
      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 -      return info.isHardwareAccelerated();
 +      return allowSoftwareCodecs ? !info.isHardwareAccelerated() : info.isHardwareAccelerated();
      }
- 
+
      switch (type) {

--- a/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
+++ b/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
@@ -41,6 +41,9 @@
    @Deprecated
 @@ -186,7 +195,7 @@
    // current SDK.
++  // Note: allowSoftwareCodecs is only effective on API 29+ (Android 10 / Q) where
++  // isHardwareAccelerated() is available. On earlier APIs the switch(type) path below
++  // is unchanged and may still select hardware encoders.
    private boolean isHardwareSupportedInCurrentSdk(MediaCodecInfo info, VideoCodecMimeType type) {
      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 -      return info.isHardwareAccelerated();

--- a/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
+++ b/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
@@ -39,7 +39,7 @@
    }
 
    @Deprecated
-@@ -186,7 +195,7 @@
+@@ -186,7 +195,10 @@
    // current SDK.
 +  // Note: allowSoftwareCodecs is only effective on API 29+ (Android 10 / Q) where
 +  // isHardwareAccelerated() is available. On earlier APIs the switch(type) path below

--- a/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
+++ b/webrtc-sys/libwebrtc/patches/sw_h264_fallback.patch
@@ -1,0 +1,93 @@
+--- a/sdk/android/api/org/webrtc/HardwareVideoEncoderFactory.java
++++ b/sdk/android/api/org/webrtc/HardwareVideoEncoderFactory.java
+@@ -47,6 +47,7 @@
+   private final boolean enableIntelVp8Encoder;
+   private final boolean enableH264HighProfile;
+   @Nullable private final Predicate<MediaCodecInfo> codecAllowedPredicate;
++  private final boolean allowSoftwareCodecs;
+ 
+   /**
+    * Creates a HardwareVideoEncoderFactory that supports surface texture encoding.
+@@ -59,7 +60,7 @@
+   public HardwareVideoEncoderFactory(
+       EglBase.Context sharedContext, boolean enableIntelVp8Encoder, boolean enableH264HighProfile) {
+     this(sharedContext, enableIntelVp8Encoder, enableH264HighProfile,
+-        /* codecAllowedPredicate= */ null);
++        /* codecAllowedPredicate= */ null, /* allowSoftwareCodecs= */ false);
+   }
+ 
+   /**
+@@ -74,6 +75,13 @@
+    */
+   public HardwareVideoEncoderFactory(EglBase.Context sharedContext, boolean enableIntelVp8Encoder,
+       boolean enableH264HighProfile, @Nullable Predicate<MediaCodecInfo> codecAllowedPredicate) {
++    this(sharedContext, enableIntelVp8Encoder, enableH264HighProfile, codecAllowedPredicate,
++        /* allowSoftwareCodecs= */ false);
++  }
++
++  public HardwareVideoEncoderFactory(EglBase.Context sharedContext, boolean enableIntelVp8Encoder,
++      boolean enableH264HighProfile, @Nullable Predicate<MediaCodecInfo> codecAllowedPredicate,
++      boolean allowSoftwareCodecs) {
+     // Texture mode requires EglBase14.
+     if (sharedContext instanceof EglBase14.Context) {
+       this.sharedContext = (EglBase14.Context) sharedContext;
+@@ -84,6 +92,50 @@
+     this.enableIntelVp8Encoder = enableIntelVp8Encoder;
+     this.enableH264HighProfile = enableH264HighProfile;
+     this.codecAllowedPredicate = codecAllowedPredicate;
++    this.allowSoftwareCodecs = allowSoftwareCodecs;
++  }
++
++  /**
++   * Returns the codec name of the first HW H264 encoder if it is on the SW-fallback blocklist
++   * (known to produce SPS NALs with a hardcoded level that breaks client decoders when the SDP
++   * negotiated Level 3.1), or {@code null} if the encoder appears compliant or no HW H264 encoder
++   * is found.
++   */
++  @Nullable
++  public static String findNonCompliantHardwareH264EncoderName() {
++    // Encoders known to produce non-standard H264 SPS at runtime regardless of what level they
++    // declare in profileLevels. Do not use a capability check here — many compliant encoders
++    // (e.g. Qualcomm c2.qti.avc.encoder) only advertise high levels without enumerating Level 3.1.
++    final String[] NAME_BLOCKLIST = {"OMX.realtek."};
++
++    final MediaCodecList list = new MediaCodecList(MediaCodecList.ALL_CODECS);
++    for (MediaCodecInfo info : list.getCodecInfos()) {
++      if (info == null || !info.isEncoder()) continue;
++      if (!MediaCodecUtils.codecSupportsType(info, VideoCodecMimeType.H264)) continue;
++
++      // Identify hardware encoders using the same criteria as isHardwareSupportedInCurrentSdk().
++      final boolean isHw;
++      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
++        isHw = info.isHardwareAccelerated();
++      } else {
++        final String n = info.getName();
++        isHw = n.startsWith(QCOM_PREFIX) || n.startsWith(EXYNOS_PREFIX)
++            || n.startsWith(INTEL_PREFIX);
++      }
++      if (!isHw) continue;
++
++      final String name = info.getName();
++      for (final String prefix : NAME_BLOCKLIST) {
++        if (name.startsWith(prefix)) {
++          Logging.w(TAG, name + " is on SW-fallback blocklist — SW encoder will be used");
++          return name;
++        }
++      }
++
++      // First HW H264 encoder found and not on blocklist — use it.
++      return null;
++    }
++    return null;
+   }
+ 
+   @Deprecated
+@@ -186,7 +238,7 @@
+   // current SDK.
+   private boolean isHardwareSupportedInCurrentSdk(MediaCodecInfo info, VideoCodecMimeType type) {
+     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+-      return info.isHardwareAccelerated();
++      return allowSoftwareCodecs ? !info.isHardwareAccelerated() : info.isHardwareAccelerated();
+     }
+ 
+     switch (type) {

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<webrtc::VideoEncoderFactory> CreateHardwareVideoEncoderFactory()
 // which inverts the isHardwareAccelerated() check so only SW MediaCodec codecs are selected
 // (e.g. c2.android.avc.encoder).  These produce standard H264 Baseline Level 3.1.
 // Note: allowSoftwareCodecs is only effective on API 29+ (Android 10+); on earlier APIs
-// the Java factory may still select hardware encoders.  All current target devices qualify.
+// the Java factory may still select hardware encoders.
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareH264VideoEncoderFactory() {
   JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
   webrtc::ScopedJavaLocalRef<jclass> factory_class =

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -172,8 +172,16 @@ AndroidVideoEncoderFactory::GetSupportedFormats() const {
   std::vector<webrtc::SdpVideoFormat> formats;
 
   if (m_hwEncoderFactory) {
-    auto hw_formats = m_hwEncoderFactory->GetSupportedFormats();
-    formats.insert(formats.end(), hw_formats.begin(), hw_formats.end());
+    for (const auto& fmt : m_hwEncoderFactory->GetSupportedFormats()) {
+      // When SW H264 is forced, exclude HW H264 formats so SDP negotiation
+      // cannot select a profile only the HW encoder supports.
+      if (m_swH264EncoderFactory && IsH264Format(fmt)) continue;
+      formats.push_back(fmt);
+    }
+  }
+  if (m_swH264EncoderFactory) {
+    auto sw_h264_formats = m_swH264EncoderFactory->GetSupportedFormats();
+    formats.insert(formats.end(), sw_h264_formats.begin(), sw_h264_formats.end());
   }
   if (m_swEncoderFactory) {
     auto sw_formats = m_swEncoderFactory->GetSupportedFormats();
@@ -203,6 +211,10 @@ webrtc::VideoEncoderFactory::CodecSupport
 AndroidVideoEncoderFactory::QueryCodecSupport(
     const webrtc::SdpVideoFormat& format,
     std::optional<std::string> scalability_mode) const {
+  if (IsH264Format(format) && m_swH264EncoderFactory) {
+    return m_swH264EncoderFactory->QueryCodecSupport(format, scalability_mode);
+  }
+
   if (m_hwEncoderFactory) {
     auto support = m_hwEncoderFactory->QueryCodecSupport(format, scalability_mode);
     if (support.is_supported) return support;
@@ -229,19 +241,16 @@ AndroidVideoEncoderFactory::QueryCodecSupport(
 std::unique_ptr<webrtc::VideoEncoder> AndroidVideoEncoderFactory::Create(
     const webrtc::Environment& env,
     const webrtc::SdpVideoFormat& format) {
-  // If force_sw_h264 was set, route H264 through the SW MediaCodec encoder.
+  // When SW H264 is forced, route H264 directly to the SW factory and never
+  // fall through to HW — even if the SW factory returns null.
   if (IsH264Format(format) && m_swH264EncoderFactory) {
-    for (const auto& supported_format : m_swH264EncoderFactory->GetSupportedFormats()) {
-      if (supported_format.IsSameCodec(format)) {
-        auto encoder = m_swH264EncoderFactory->Create(env, format);
-        if (encoder) {
-          RTC_LOG(LS_INFO) << "Created SW H264 encoder (force_sw_h264) for " << format.name;
-          return encoder;
-        }
-      }
+    auto encoder = m_swH264EncoderFactory->Create(env, format);
+    if (encoder) {
+      RTC_LOG(LS_INFO) << "Created SW H264 encoder (force_sw_h264) for " << format.name;
+    } else {
+      RTC_LOG(LS_WARNING) << "SW H264 factory returned no encoder for " << format.name;
     }
-    RTC_LOG(LS_WARNING) << "SW H264 factory returned no encoder for " << format.name
-                        << " — falling through";
+    return encoder;
   }
 
   if (m_hwEncoderFactory) {

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -209,8 +209,9 @@ AndroidVideoEncoderFactory::GetSupportedFormats() const {
     }
   }
   if (m_swH264EncoderFactory) {
-    auto sw_h264_formats = m_swH264EncoderFactory->GetSupportedFormats();
-    formats.insert(formats.end(), sw_h264_formats.begin(), sw_h264_formats.end());
+    for (const auto& fmt : m_swH264EncoderFactory->GetSupportedFormats()) {
+      if (IsH264Format(fmt)) formats.push_back(fmt);
+    }
   }
   if (m_swEncoderFactory) {
     for (const auto& fmt : m_swEncoderFactory->GetSupportedFormats()) {

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -99,6 +99,7 @@ std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareH264VideoEncoderFacto
       /*allowSoftwareCodecs=*/static_cast<jboolean>(true));
 
   if (!encoder_factory) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
     RTC_LOG(LS_WARNING) << "Failed to instantiate SW H264 encoder factory";
     return nullptr;
   }
@@ -136,9 +137,14 @@ AndroidVideoEncoderFactory::AndroidVideoEncoderFactory(bool force_sw_h264)
       m_hwEncoderFactory(CreateHardwareVideoEncoderFactory()),
       m_swEncoderFactory(CreateSoftwareVideoEncoderFactory()) {
   if (force_sw_h264) {
-    RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory: force_sw_h264=true "
-                        "— SW H264 encoder (c2.android.avc.encoder) will be used";
     m_swH264EncoderFactory = CreateSoftwareH264VideoEncoderFactory();
+    if (m_swH264EncoderFactory) {
+      RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory: force_sw_h264=true "
+                          "— SW H264 encoder (c2.android.avc.encoder) will be used";
+    } else {
+      RTC_LOG(LS_WARNING) << "AndroidVideoEncoderFactory: force_sw_h264=true "
+                             "but SW H264 factory unavailable — falling back to HW H264";
+    }
   } else {
     RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory: force_sw_h264=false "
                         "— HW H264 encoder will be used";

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -120,41 +120,7 @@ std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareVideoEncoderFactory()
   return webrtc::JavaToNativeVideoEncoderFactory(env, encoder_factory);
 }
 
-// Calls HardwareVideoEncoderFactory.findNonCompliantHardwareH264EncoderName() via JNI.
-// Returns the encoder name (non-empty) if the first HW H264 encoder is on the blocklist,
-// or empty string if the encoder is compliant or no HW H264 encoder is present.
-std::string GetNonCompliantHardwareH264EncoderName() {
-  JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
-  webrtc::ScopedJavaLocalRef<jclass> factory_class =
-      webrtc::GetClass(env, "livekit/org/webrtc/HardwareVideoEncoderFactory");
-  if (!factory_class.obj()) return "";
-
-  jmethodID method = env->GetStaticMethodID(
-      factory_class.obj(), "findNonCompliantHardwareH264EncoderName",
-      "()Ljava/lang/String;");
-  if (!method) {
-    if (env->ExceptionCheck()) env->ExceptionClear();
-    RTC_LOG(LS_WARNING) << "findNonCompliantHardwareH264EncoderName not found "
-                           "— libwebrtc.jar may be stale; assuming HW encoder is compliant";
-    return "";
-  }
-
-  jstring name_jstr = static_cast<jstring>(
-      env->CallStaticObjectMethod(factory_class.obj(), method));
-  if (!name_jstr) return "";
-
-  const char* chars = env->GetStringUTFChars(name_jstr, nullptr);
-  std::string name(chars);
-  env->ReleaseStringUTFChars(name_jstr, chars);
-  return name;
-}
-
 }  // namespace
-
-// Public probe function — the application calls this once at startup.
-bool AndroidH264NeedsSwFallback() {
-  return !GetNonCompliantHardwareH264EncoderName().empty();
-}
 
 // AndroidVideoEncoderFactory implementation
 AndroidVideoEncoderFactory::AndroidVideoEncoderFactory(bool force_sw_h264)

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -19,7 +19,9 @@
 #include <jni.h>
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "api/video_codecs/sdp_video_format.h"
@@ -44,9 +46,9 @@
 
 namespace livekit {
 
-// Helper function to create hardware encoder factory
-std::unique_ptr<webrtc::VideoEncoderFactory>
-CreateHardwareVideoEncoderFactory() {
+namespace {
+
+std::unique_ptr<webrtc::VideoEncoderFactory> CreateHardwareVideoEncoderFactory() {
   JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
   webrtc::ScopedJavaLocalRef<jclass> factory_class =
       webrtc::GetClass(env, "livekit/org/webrtc/HardwareVideoEncoderFactory");
@@ -56,19 +58,54 @@ CreateHardwareVideoEncoderFactory() {
     return nullptr;
   }
 
-  jmethodID ctor =
-      env->GetMethodID(factory_class.obj(), "<init>",
-                       "(Llivekit/org/webrtc/EglBase$Context;ZZ)V");
-
+  jmethodID ctor = env->GetMethodID(factory_class.obj(), "<init>",
+                                    "(Llivekit/org/webrtc/EglBase$Context;ZZ)V");
   jobject encoder_factory =
       env->NewObject(factory_class.obj(), ctor, nullptr, true, false);
-
   return webrtc::JavaToNativeVideoEncoderFactory(env, encoder_factory);
 }
 
-// Helper function to create software encoder factory
-std::unique_ptr<webrtc::VideoEncoderFactory>
-CreateSoftwareVideoEncoderFactory() {
+// Creates a HardwareVideoEncoderFactory(null, false, false, null, allowSoftwareCodecs=true),
+// which inverts the isHardwareAccelerated() check so only SW MediaCodec codecs are selected
+// (e.g. c2.android.avc.encoder).  These produce standard H264 Baseline Level 3.1.
+std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareH264VideoEncoderFactory() {
+  JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
+  webrtc::ScopedJavaLocalRef<jclass> factory_class =
+      webrtc::GetClass(env, "livekit/org/webrtc/HardwareVideoEncoderFactory");
+
+  if (!factory_class.obj()) {
+    RTC_LOG(LS_WARNING) << "HardwareVideoEncoderFactory class not found (SW H264)";
+    return nullptr;
+  }
+
+  // (EglBase$Context, boolean, boolean, Predicate, boolean)
+  jmethodID ctor = env->GetMethodID(
+      factory_class.obj(), "<init>",
+      "(Llivekit/org/webrtc/EglBase$Context;ZZLlivekit/org/webrtc/Predicate;Z)V");
+
+  if (!ctor) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
+    RTC_LOG(LS_WARNING) << "5-param HardwareVideoEncoderFactory ctor not found "
+                           "— libwebrtc.jar may be stale; SW H264 factory unavailable";
+    return nullptr;
+  }
+
+  jobject encoder_factory = env->NewObject(
+      factory_class.obj(), ctor,
+      /*sharedContext=*/nullptr,
+      /*enableIntelVp8Encoder=*/static_cast<jboolean>(false),
+      /*enableH264HighProfile=*/static_cast<jboolean>(false),
+      /*codecAllowedPredicate=*/nullptr,
+      /*allowSoftwareCodecs=*/static_cast<jboolean>(true));
+
+  if (!encoder_factory) {
+    RTC_LOG(LS_WARNING) << "Failed to instantiate SW H264 encoder factory";
+    return nullptr;
+  }
+  return webrtc::JavaToNativeVideoEncoderFactory(env, encoder_factory);
+}
+
+std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareVideoEncoderFactory() {
   JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
   webrtc::ScopedJavaLocalRef<jclass> factory_class =
       webrtc::GetClass(env, "livekit/org/webrtc/SoftwareVideoEncoderFactory");
@@ -80,12 +117,47 @@ CreateSoftwareVideoEncoderFactory() {
 
   jmethodID ctor = env->GetMethodID(factory_class.obj(), "<init>", "()V");
   jobject encoder_factory = env->NewObject(factory_class.obj(), ctor);
-
   return webrtc::JavaToNativeVideoEncoderFactory(env, encoder_factory);
 }
 
+// Calls HardwareVideoEncoderFactory.findNonCompliantHardwareH264EncoderName() via JNI.
+// Returns the encoder name (non-empty) if the first HW H264 encoder is on the blocklist,
+// or empty string if the encoder is compliant or no HW H264 encoder is present.
+std::string GetNonCompliantHardwareH264EncoderName() {
+  JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
+  webrtc::ScopedJavaLocalRef<jclass> factory_class =
+      webrtc::GetClass(env, "livekit/org/webrtc/HardwareVideoEncoderFactory");
+  if (!factory_class.obj()) return "";
+
+  jmethodID method = env->GetStaticMethodID(
+      factory_class.obj(), "findNonCompliantHardwareH264EncoderName",
+      "()Ljava/lang/String;");
+  if (!method) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
+    RTC_LOG(LS_WARNING) << "findNonCompliantHardwareH264EncoderName not found "
+                           "— libwebrtc.jar may be stale; assuming HW encoder is compliant";
+    return "";
+  }
+
+  jstring name_jstr = static_cast<jstring>(
+      env->CallStaticObjectMethod(factory_class.obj(), method));
+  if (!name_jstr) return "";
+
+  const char* chars = env->GetStringUTFChars(name_jstr, nullptr);
+  std::string name(chars);
+  env->ReleaseStringUTFChars(name_jstr, chars);
+  return name;
+}
+
+}  // namespace
+
+// Public probe function — the application calls this once at startup.
+bool AndroidH264NeedsSwFallback() {
+  return !GetNonCompliantHardwareH264EncoderName().empty();
+}
+
 // AndroidVideoEncoderFactory implementation
-AndroidVideoEncoderFactory::AndroidVideoEncoderFactory()
+AndroidVideoEncoderFactory::AndroidVideoEncoderFactory(bool force_sw_h264)
     : m_builtinEncoderFactory([]() {
         using Factory = webrtc::VideoEncoderFactoryTemplate<
             webrtc::LibvpxVp8EncoderTemplateAdapter,
@@ -97,7 +169,14 @@ AndroidVideoEncoderFactory::AndroidVideoEncoderFactory()
       }()),
       m_hwEncoderFactory(CreateHardwareVideoEncoderFactory()),
       m_swEncoderFactory(CreateSoftwareVideoEncoderFactory()) {
-  RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory created";
+  if (force_sw_h264) {
+    RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory: force_sw_h264=true "
+                        "— SW H264 encoder (c2.android.avc.encoder) will be used";
+    m_swH264EncoderFactory = CreateSoftwareH264VideoEncoderFactory();
+  } else {
+    RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory: force_sw_h264=false "
+                        "— HW H264 encoder will be used";
+  }
 }
 
 AndroidVideoEncoderFactory::~AndroidVideoEncoderFactory() {
@@ -111,19 +190,14 @@ bool AndroidVideoEncoderFactory::IsH264Format(
 
 void AndroidVideoEncoderFactory::EnsureH264InSupportedFormats(
     std::vector<webrtc::SdpVideoFormat>& formats) const {
-  // Check if H.264 is already in the supported formats
   for (const auto& format : formats) {
-    if (IsH264Format(format)) {
-      return;  // H.264 already supported
-    }
+    if (IsH264Format(format)) return;
   }
 
-  // Add H.264 format if not present
   webrtc::SdpVideoFormat h264_format(cricket::kH264CodecName);
   h264_format.parameters[cricket::kH264FmtpProfileLevelId] =
       cricket::kH264ProfileLevelConstrainedBaseline;
   formats.push_back(h264_format);
-
   RTC_LOG(LS_INFO) << "Added H.264 to supported formats";
 }
 
@@ -131,39 +205,31 @@ std::vector<webrtc::SdpVideoFormat>
 AndroidVideoEncoderFactory::GetSupportedFormats() const {
   std::vector<webrtc::SdpVideoFormat> formats;
 
-  // Get formats from hardware factory
   if (m_hwEncoderFactory) {
     auto hw_formats = m_hwEncoderFactory->GetSupportedFormats();
     formats.insert(formats.end(), hw_formats.begin(), hw_formats.end());
   }
-
-  // Get formats from software factory
   if (m_swEncoderFactory) {
     auto sw_formats = m_swEncoderFactory->GetSupportedFormats();
     formats.insert(formats.end(), sw_formats.begin(), sw_formats.end());
   }
-
-  // Get formats from builtin factory
   if (m_builtinEncoderFactory) {
     auto builtin_formats = m_builtinEncoderFactory->GetSupportedFormats();
-    formats.insert(formats.end(), builtin_formats.begin(),
-                   builtin_formats.end());
+    formats.insert(formats.end(), builtin_formats.begin(), builtin_formats.end());
   }
 
-  // Ensure H.264 is in supported formats
   EnsureH264InSupportedFormats(formats);
 
-  // Remove duplicates
   std::sort(formats.begin(), formats.end(),
-            [](const webrtc::SdpVideoFormat& a,
-               const webrtc::SdpVideoFormat& b) { return a.name < b.name; });
+            [](const webrtc::SdpVideoFormat& a, const webrtc::SdpVideoFormat& b) {
+              return a.name < b.name;
+            });
   formats.erase(std::unique(formats.begin(), formats.end(),
                             [](const webrtc::SdpVideoFormat& a,
                                const webrtc::SdpVideoFormat& b) {
                               return a.IsSameCodec(b);
                             }),
                 formats.end());
-
   return formats;
 }
 
@@ -171,32 +237,22 @@ webrtc::VideoEncoderFactory::CodecSupport
 AndroidVideoEncoderFactory::QueryCodecSupport(
     const webrtc::SdpVideoFormat& format,
     std::optional<std::string> scalability_mode) const {
-  // Try hardware factory first
   if (m_hwEncoderFactory) {
-    auto support =
-        m_hwEncoderFactory->QueryCodecSupport(format, scalability_mode);
-    if (support.is_supported) {
-      return support;
-    }
+    auto support = m_hwEncoderFactory->QueryCodecSupport(format, scalability_mode);
+    if (support.is_supported) return support;
   }
 
-  // For H.264, we always support it via X264
   if (IsH264Format(format)) {
 #if defined(WEBRTC_USE_X264) && defined(WEBRTC_ANDROID)
     return {.is_supported = true, .is_power_efficient = false};
 #endif
   }
 
-  // Try software factory
   if (m_swEncoderFactory) {
-    auto support =
-        m_swEncoderFactory->QueryCodecSupport(format, scalability_mode);
-    if (support.is_supported) {
-      return support;
-    }
+    auto support = m_swEncoderFactory->QueryCodecSupport(format, scalability_mode);
+    if (support.is_supported) return support;
   }
 
-  // Try builtin factory
   if (m_builtinEncoderFactory) {
     return m_builtinEncoderFactory->QueryCodecSupport(format, scalability_mode);
   }
@@ -207,10 +263,23 @@ AndroidVideoEncoderFactory::QueryCodecSupport(
 std::unique_ptr<webrtc::VideoEncoder> AndroidVideoEncoderFactory::Create(
     const webrtc::Environment& env,
     const webrtc::SdpVideoFormat& format) {
-  // Try hardware factory first
+  // If force_sw_h264 was set, route H264 through the SW MediaCodec encoder.
+  if (IsH264Format(format) && m_swH264EncoderFactory) {
+    for (const auto& supported_format : m_swH264EncoderFactory->GetSupportedFormats()) {
+      if (supported_format.IsSameCodec(format)) {
+        auto encoder = m_swH264EncoderFactory->Create(env, format);
+        if (encoder) {
+          RTC_LOG(LS_INFO) << "Created SW H264 encoder (force_sw_h264) for " << format.name;
+          return encoder;
+        }
+      }
+    }
+    RTC_LOG(LS_WARNING) << "SW H264 factory returned no encoder for " << format.name
+                        << " — falling through";
+  }
+
   if (m_hwEncoderFactory) {
-    for (const auto& supported_format :
-         m_hwEncoderFactory->GetSupportedFormats()) {
+    for (const auto& supported_format : m_hwEncoderFactory->GetSupportedFormats()) {
       if (supported_format.IsSameCodec(format)) {
         auto encoder = m_hwEncoderFactory->Create(env, format);
         if (encoder) {
@@ -221,7 +290,6 @@ std::unique_ptr<webrtc::VideoEncoder> AndroidVideoEncoderFactory::Create(
     }
   }
 
-  // For H.264, create X264VideoEncoder
   if (IsH264Format(format)) {
 #if defined(WEBRTC_USE_X264) && defined(WEBRTC_ANDROID)
     RTC_LOG(LS_INFO) << "Creating X264VideoEncoder for H.264";
@@ -229,10 +297,8 @@ std::unique_ptr<webrtc::VideoEncoder> AndroidVideoEncoderFactory::Create(
 #endif
   }
 
-  // Try software factory
   if (m_swEncoderFactory) {
-    for (const auto& supported_format :
-         m_swEncoderFactory->GetSupportedFormats()) {
+    for (const auto& supported_format : m_swEncoderFactory->GetSupportedFormats()) {
       if (supported_format.IsSameCodec(format)) {
         auto encoder = m_swEncoderFactory->Create(env, format);
         if (encoder) {
@@ -243,10 +309,8 @@ std::unique_ptr<webrtc::VideoEncoder> AndroidVideoEncoderFactory::Create(
     }
   }
 
-  // Try builtin factory
   if (m_builtinEncoderFactory) {
-    for (const auto& supported_format :
-         m_builtinEncoderFactory->GetSupportedFormats()) {
+    for (const auto& supported_format : m_builtinEncoderFactory->GetSupportedFormats()) {
       if (supported_format.IsSameCodec(format)) {
         auto encoder = m_builtinEncoderFactory->Create(env, format);
         if (encoder) {
@@ -261,10 +325,11 @@ std::unique_ptr<webrtc::VideoEncoder> AndroidVideoEncoderFactory::Create(
   return nullptr;
 }
 
-std::unique_ptr<webrtc::VideoEncoderFactory>
-CreateAndroidVideoEncoderFactory() {
-  RTC_LOG(LS_INFO) << "Creating AndroidVideoEncoderFactory";
-  return std::make_unique<AndroidVideoEncoderFactory>();
+std::unique_ptr<webrtc::VideoEncoderFactory> CreateAndroidVideoEncoderFactory(
+    bool force_sw_h264) {
+  RTC_LOG(LS_INFO) << "Creating AndroidVideoEncoderFactory (force_sw_h264="
+                   << force_sw_h264 << ")";
+  return std::make_unique<AndroidVideoEncoderFactory>(force_sw_h264);
 }
 
 }  // namespace livekit

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -19,7 +19,6 @@
 #include <jni.h>
 
 #include <algorithm>
-#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
@@ -79,6 +78,8 @@ std::unique_ptr<webrtc::VideoEncoderFactory> CreateHardwareVideoEncoderFactory()
 // Creates a HardwareVideoEncoderFactory(null, false, false, null, allowSoftwareCodecs=true),
 // which inverts the isHardwareAccelerated() check so only SW MediaCodec codecs are selected
 // (e.g. c2.android.avc.encoder).  These produce standard H264 Baseline Level 3.1.
+// Note: allowSoftwareCodecs is only effective on API 29+ (Android 10+); on earlier APIs
+// the Java factory may still select hardware encoders.  All current target devices qualify.
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareH264VideoEncoderFactory() {
   JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
   webrtc::ScopedJavaLocalRef<jclass> factory_class =

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -220,7 +220,12 @@ AndroidVideoEncoderFactory::GetSupportedFormats() const {
     formats.insert(formats.end(), builtin_formats.begin(), builtin_formats.end());
   }
 
-  EnsureH264InSupportedFormats(formats);
+  // Skip synthetic H264 injection when the SW factory is active — it already
+  // advertises its own H264 formats, and Create() never falls back to HW/x264
+  // for H264 in that mode, so a synthetic entry could negotiate an unencodable format.
+  if (!m_swH264EncoderFactory) {
+    EnsureH264InSupportedFormats(formats);
+  }
 
   // Sort by (name, parameters) so same-codec variants are adjacent for unique().
   std::sort(formats.begin(), formats.end(),

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -170,7 +170,7 @@ AndroidVideoEncoderFactory::AndroidVideoEncoderFactory(bool force_sw_h264)
     }
   } else {
     RTC_LOG(LS_INFO) << "AndroidVideoEncoderFactory: force_sw_h264=false "
-                        "— HW H264 encoder will be used";
+                        "— HW H264 encoder preferred (x264/SW fallback if unavailable)";
   }
 }
 

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -213,12 +213,16 @@ AndroidVideoEncoderFactory::GetSupportedFormats() const {
     formats.insert(formats.end(), sw_h264_formats.begin(), sw_h264_formats.end());
   }
   if (m_swEncoderFactory) {
-    auto sw_formats = m_swEncoderFactory->GetSupportedFormats();
-    formats.insert(formats.end(), sw_formats.begin(), sw_formats.end());
+    for (const auto& fmt : m_swEncoderFactory->GetSupportedFormats()) {
+      if (m_swH264EncoderFactory && IsH264Format(fmt)) continue;
+      formats.push_back(fmt);
+    }
   }
   if (m_builtinEncoderFactory) {
-    auto builtin_formats = m_builtinEncoderFactory->GetSupportedFormats();
-    formats.insert(formats.end(), builtin_formats.begin(), builtin_formats.end());
+    for (const auto& fmt : m_builtinEncoderFactory->GetSupportedFormats()) {
+      if (m_swH264EncoderFactory && IsH264Format(fmt)) continue;
+      formats.push_back(fmt);
+    }
   }
 
   // Skip synthetic H264 injection when the SW factory is active — it already

--- a/webrtc-sys/src/android/video_encoder_factory.cpp
+++ b/webrtc-sys/src/android/video_encoder_factory.cpp
@@ -60,8 +60,19 @@ std::unique_ptr<webrtc::VideoEncoderFactory> CreateHardwareVideoEncoderFactory()
 
   jmethodID ctor = env->GetMethodID(factory_class.obj(), "<init>",
                                     "(Llivekit/org/webrtc/EglBase$Context;ZZ)V");
+  if (!ctor) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
+    RTC_LOG(LS_WARNING) << "HardwareVideoEncoderFactory ctor not found";
+    return nullptr;
+  }
+
   jobject encoder_factory =
       env->NewObject(factory_class.obj(), ctor, nullptr, true, false);
+  if (!encoder_factory) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
+    RTC_LOG(LS_WARNING) << "Failed to instantiate HardwareVideoEncoderFactory";
+    return nullptr;
+  }
   return webrtc::JavaToNativeVideoEncoderFactory(env, encoder_factory);
 }
 
@@ -117,7 +128,18 @@ std::unique_ptr<webrtc::VideoEncoderFactory> CreateSoftwareVideoEncoderFactory()
   }
 
   jmethodID ctor = env->GetMethodID(factory_class.obj(), "<init>", "()V");
+  if (!ctor) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
+    RTC_LOG(LS_WARNING) << "SoftwareVideoEncoderFactory ctor not found";
+    return nullptr;
+  }
+
   jobject encoder_factory = env->NewObject(factory_class.obj(), ctor);
+  if (!encoder_factory) {
+    if (env->ExceptionCheck()) env->ExceptionClear();
+    RTC_LOG(LS_WARNING) << "Failed to instantiate SoftwareVideoEncoderFactory";
+    return nullptr;
+  }
   return webrtc::JavaToNativeVideoEncoderFactory(env, encoder_factory);
 }
 
@@ -200,9 +222,10 @@ AndroidVideoEncoderFactory::GetSupportedFormats() const {
 
   EnsureH264InSupportedFormats(formats);
 
+  // Sort by (name, parameters) so same-codec variants are adjacent for unique().
   std::sort(formats.begin(), formats.end(),
             [](const webrtc::SdpVideoFormat& a, const webrtc::SdpVideoFormat& b) {
-              return a.name < b.name;
+              return a.name < b.name || (a.name == b.name && a.parameters < b.parameters);
             });
   formats.erase(std::unique(formats.begin(), formats.end(),
                             [](const webrtc::SdpVideoFormat& a,

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -38,6 +38,9 @@
 #include "livekit/rtp_parameters.h"
 #include "livekit/video_decoder_factory.h"
 #include "livekit/video_encoder_factory.h"
+#ifdef WEBRTC_ANDROID
+#include "livekit/android/video_encoder_factory.h"
+#endif
 #include "livekit/webrtc.h"
 #include "rtc_base/thread.h"
 #include "webrtc-sys/src/peer_connection.rs.h"
@@ -48,7 +51,7 @@ namespace livekit {
 class PeerConnectionObserver;
 
 PeerConnectionFactory::PeerConnectionFactory(
-    std::shared_ptr<RtcRuntime> rtc_runtime)
+    std::shared_ptr<RtcRuntime> rtc_runtime, bool force_sw_h264)
     : rtc_runtime_(rtc_runtime) {
   RTC_LOG(LS_VERBOSE) << "PeerConnectionFactory::PeerConnectionFactory()";
 
@@ -69,7 +72,7 @@ PeerConnectionFactory::PeerConnectionFactory(
   dependencies.adm = audio_device_;
 
   dependencies.video_encoder_factory =
-      std::move(std::make_unique<livekit::VideoEncoderFactory>());
+      std::move(std::make_unique<livekit::VideoEncoderFactory>(force_sw_h264));
   dependencies.video_decoder_factory =
       std::move(std::make_unique<livekit::VideoDecoderFactory>());
   dependencies.audio_encoder_factory = webrtc::CreateBuiltinAudioEncoderFactory();
@@ -140,8 +143,18 @@ RtpCapabilities PeerConnectionFactory::rtp_receiver_capabilities(
       static_cast<webrtc::MediaType>(type)));
 }
 
-std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory() {
-  return std::make_shared<PeerConnectionFactory>(RtcRuntime::create());
+std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory(
+    bool force_sw_h264) {
+  return std::make_shared<PeerConnectionFactory>(RtcRuntime::create(),
+                                                 force_sw_h264);
+}
+
+bool android_h264_needs_sw_fallback() {
+#ifdef WEBRTC_ANDROID
+  return AndroidH264NeedsSwFallback();
+#else
+  return false;
+#endif
 }
 
 }  // namespace livekit

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -38,9 +38,6 @@
 #include "livekit/rtp_parameters.h"
 #include "livekit/video_decoder_factory.h"
 #include "livekit/video_encoder_factory.h"
-#ifdef WEBRTC_ANDROID
-#include "livekit/android/video_encoder_factory.h"
-#endif
 #include "livekit/webrtc.h"
 #include "rtc_base/thread.h"
 #include "webrtc-sys/src/peer_connection.rs.h"

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -149,12 +149,5 @@ std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory(
                                                  force_sw_h264);
 }
 
-bool android_h264_needs_sw_fallback() {
-#ifdef WEBRTC_ANDROID
-  return AndroidH264NeedsSwFallback();
-#else
-  return false;
-#endif
-}
 
 }  // namespace livekit

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -69,9 +69,9 @@ PeerConnectionFactory::PeerConnectionFactory(
   dependencies.adm = audio_device_;
 
   dependencies.video_encoder_factory =
-      std::move(std::make_unique<livekit::VideoEncoderFactory>(force_sw_h264));
+      std::make_unique<livekit::VideoEncoderFactory>(force_sw_h264);
   dependencies.video_decoder_factory =
-      std::move(std::make_unique<livekit::VideoDecoderFactory>());
+      std::make_unique<livekit::VideoDecoderFactory>();
   dependencies.audio_encoder_factory = webrtc::CreateBuiltinAudioEncoderFactory();
   dependencies.audio_decoder_factory = webrtc::CreateBuiltinAudioDecoderFactory();
   dependencies.audio_processing = webrtc::BuiltinAudioProcessingBuilder()

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -87,7 +87,18 @@ pub mod ffi {
         type PeerConnection = crate::peer_connection::ffi::PeerConnection;
         type PeerConnectionFactory;
 
-        fn create_peer_connection_factory() -> SharedPtr<PeerConnectionFactory>;
+        // Returns true if the first HW H264 encoder on this device is on the
+        // SW-fallback blocklist.  Always returns false on non-Android platforms.
+        // Call once at startup to determine the force_sw_h264 flag below.
+        fn android_h264_needs_sw_fallback() -> bool;
+
+        // Creates a PeerConnectionFactory.
+        // force_sw_h264: when true, H264 is always encoded via the SW MediaCodec
+        // encoder.  Call android_h264_needs_sw_fallback() first and pass its
+        // return value here; the library no longer auto-detects this.
+        fn create_peer_connection_factory(
+            force_sw_h264: bool,
+        ) -> SharedPtr<PeerConnectionFactory>;
 
         fn create_peer_connection(
             self: &PeerConnectionFactory,

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -87,15 +87,9 @@ pub mod ffi {
         type PeerConnection = crate::peer_connection::ffi::PeerConnection;
         type PeerConnectionFactory;
 
-        // Returns true if the first HW H264 encoder on this device is on the
-        // SW-fallback blocklist.  Always returns false on non-Android platforms.
-        // Call once at startup to determine the force_sw_h264 flag below.
-        fn android_h264_needs_sw_fallback() -> bool;
-
         // Creates a PeerConnectionFactory.
         // force_sw_h264: when true, H264 is always encoded via the SW MediaCodec
-        // encoder.  Call android_h264_needs_sw_fallback() first and pass its
-        // return value here; the library no longer auto-detects this.
+        // encoder (c2.android.avc.encoder) instead of the HW encoder.
         fn create_peer_connection_factory(
             force_sw_h264: bool,
         ) -> SharedPtr<PeerConnectionFactory>;

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -88,8 +88,9 @@ pub mod ffi {
         type PeerConnectionFactory;
 
         // Creates a PeerConnectionFactory.
-        // force_sw_h264: when true, H264 is always encoded via the SW MediaCodec
-        // encoder (c2.android.avc.encoder) instead of the HW encoder.
+        // force_sw_h264: when true, H264 encoding prefers the SW MediaCodec encoder
+        // (c2.android.avc.encoder) over the HW encoder.  Best-effort: falls back
+        // to HW if the SW factory cannot be created.  Effective on API 29+ only.
         fn create_peer_connection_factory(
             force_sw_h264: bool,
         ) -> SharedPtr<PeerConnectionFactory>;

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -64,6 +64,8 @@ VideoEncoderFactory::InternalFactory::InternalFactory(bool force_sw_h264) {
 
 #ifdef WEBRTC_ANDROID
   factories_.push_back(CreateAndroidVideoEncoderFactory(force_sw_h264));
+#else
+  (void)force_sw_h264;
 #endif
 
 #if defined(USE_NVIDIA_VIDEO_CODEC)

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -57,13 +57,13 @@ using Factory = webrtc::VideoEncoderFactoryTemplate<
 #endif
     webrtc::LibvpxVp9EncoderTemplateAdapter>;
 
-VideoEncoderFactory::InternalFactory::InternalFactory() {
+VideoEncoderFactory::InternalFactory::InternalFactory(bool force_sw_h264) {
 #ifdef __APPLE__
   factories_.push_back(livekit::CreateObjCVideoEncoderFactory());
 #endif
 
 #ifdef WEBRTC_ANDROID
-  factories_.push_back(CreateAndroidVideoEncoderFactory());
+  factories_.push_back(CreateAndroidVideoEncoderFactory(force_sw_h264));
 #endif
 
 #if defined(USE_NVIDIA_VIDEO_CODEC)
@@ -128,8 +128,8 @@ VideoEncoderFactory::InternalFactory::Create(
   return nullptr;
 }
 
-VideoEncoderFactory::VideoEncoderFactory() {
-  internal_factory_ = std::make_unique<InternalFactory>();
+VideoEncoderFactory::VideoEncoderFactory(bool force_sw_h264) {
+  internal_factory_ = std::make_unique<InternalFactory>(force_sw_h264);
 }
 
 std::vector<webrtc::SdpVideoFormat> VideoEncoderFactory::GetSupportedFormats()


### PR DESCRIPTION
 AB#135683

## Pull request overview

This PR adds an end-to-end toggle (FFI → Rust → C++ → Android Java) to force H264 encoding through the Android *software* MediaCodec encoder (`c2.android.avc.encoder`) to work around non-compliant hardware H264 encoders impacting simulcast. It also introduces a libwebrtc patch to allow selecting software MediaCodec codecs via `HardwareVideoEncoderFactory`.

**Changes:**
- Added `livekit_ffi_set_force_sw_h264(bool)` and plumbed the flag through `LkRuntime` into `PeerConnectionFactory` / `VideoEncoderFactory` on Android.
- Implemented an Android SW-H264-specific encoder factory path by instantiating a patched `HardwareVideoEncoderFactory(..., allowSoftwareCodecs=true)`.
- Updated Android libwebrtc build inputs to apply the new Java patch and adjusted Android sysroot configuration.